### PR TITLE
Don't use personal PAT for forked PRs

### DIFF
--- a/.github/workflows/build-calendars.yaml
+++ b/.github/workflows/build-calendars.yaml
@@ -57,7 +57,7 @@ jobs:
     - name: Update draft release with build artefacts
       uses: beyarkay/update-existing-release@master
       with:
-        token: ${{ secrets.GH_ACTIONS_PAT }}
+        token: ${{ secrets.GH_ACTIONS_PAT || github.token }}
         release: Draft release with build artefacts
         updateTag: true
         tag: builds

--- a/.github/workflows/build-calendars.yaml
+++ b/.github/workflows/build-calendars.yaml
@@ -56,6 +56,7 @@ jobs:
 
     - name: Update draft release with build artefacts
       uses: beyarkay/update-existing-release@master
+      continue-on-error: true # this step fails on PRs originating from a FORK
       with:
         token: ${{ secrets.GH_ACTIONS_PAT || github.token }}
         release: Draft release with build artefacts


### PR DESCRIPTION
This change should fix https://github.com/beyarkay/eskom-calendar/issues/128 based on the comment in https://github.com/actions/checkout/issues/298#issuecomment-820748989 which suggests using GHs truthy behaviour to use the personal PAT if available, and falling back onto the token APT if not available.