### PR TITLE
Add 1hr alarm to all calendar events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,11 +455,13 @@ dependencies = [
 
 [[package]]
 name = "icalendar"
-version = "0.13.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f667625399cbff40e24172d0b3dae49ff51db305bee0facd67063b1fbdc15e"
+checksum = "4f730bf0dc0a06f7e19c4ca6b731427d741384338b60128e5d0d00aeb0b5f071"
 dependencies = [
  "chrono",
+ "iso8601",
+ "nom",
  "uuid",
 ]
 
@@ -494,6 +496,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "iso8601"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -560,6 +571,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 chrono = "0.4.19"
-icalendar = "0.13.0"
+icalendar = "0.15.4"
 csv = "1.1"
 regex = "1.6.0"
 pretty_env_logger = "0.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,8 +352,11 @@ fn gen_datetimes(
 mod fmt {
     use crate::get_git_hash;
     use crate::BoxedError;
+    use chrono::Duration;
     use chrono::FixedOffset;
     use chrono::{DateTime, Utc};
+    use icalendar::Alarm;
+    use icalendar::EventLike;
     use icalendar::{Component, Event};
     use std::path::Path;
 
@@ -437,6 +440,7 @@ mod fmt {
             .description(description.as_str())
             .starts(power_outage.start.with_timezone(&Utc))
             .ends(power_outage.finsh.with_timezone(&Utc))
+            .alarm(Alarm::display(&format!("In 1 hour: {}", summary), -Duration::hours(1)))
             .done();
         Ok(evt)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,7 +440,10 @@ mod fmt {
             .description(description.as_str())
             .starts(power_outage.start.with_timezone(&Utc))
             .ends(power_outage.finsh.with_timezone(&Utc))
-            .alarm(Alarm::display(&format!("In 1 hour: {}", summary), -Duration::hours(1)))
+            .alarm(Alarm::display(
+                &format!("In 1 hour: {}", summary),
+                -Duration::hours(1),
+            ))
             .done();
         Ok(evt)
     }


### PR DESCRIPTION
This PR adds a notification event which will give the use some prior warning, exactly 1 hour before every loadshedding event. 
@shaunkleyn  @cliffbattco do you have any strong opinions about this?