### PR TITLE
CPT twitter loadshedding update

### DIFF
--- a/manually_specified.yaml
+++ b/manually_specified.yaml
@@ -17,34 +17,29 @@ changes:
   finsh: 2023-05-12T15:00:00
   source: https://twitter.com/Eskom_SA/status/1654814465508925442
   exclude: coct
-- stage: 4
-  start: 2023-05-06T13:00:00
-  finsh: 2023-05-06T16:00:00
+- stage: 5
+  start: '2023-05-06T16:00:00'
+  finsh: '2023-05-07T05:00:00'
   source: https://twitter.com/CityofCT/status/1654829406433542144
   include: coct
 - stage: 5
-  start: 2023-05-06T16:00:00
-  finsh: 2023-05-07T05:00:00
-  source: https://twitter.com/CityofCT/status/1654829406433542144
-  include: coct
-- stage: 5
-  start: 2023-05-07T05:00:00
-  finsh: 2023-05-08T05:00:00
+  start: '2023-05-07T05:00:00'
+  finsh: '2023-05-08T05:00:00'
   source: https://twitter.com/CityofCT/status/1654829406433542144
   include: coct
 - stage: 4
-  start: 2023-05-08T05:00:00
-  finsh: 2023-05-08T16:00:00
+  start: '2023-05-08T05:00:00'
+  finsh: '2023-05-08T16:00:00'
   source: https://twitter.com/CityofCT/status/1654829406433542144
   include: coct
 - stage: 3
-  start: 2023-05-08T16:00:00
-  finsh: 2023-05-08T20:00:00
+  start: '2023-05-08T16:00:00'
+  finsh: '2023-05-08T20:00:00'
   source: https://twitter.com/CityofCT/status/1654829406433542144
   include: coct
 - stage: 5
-  start: 2023-05-08T20:00:00
-  finsh: 2023-05-09T05:00:00
+  start: '2023-05-08T20:00:00'
+  finsh: '2023-05-09T05:00:00'
   source: https://twitter.com/CityofCT/status/1654829406433542144
   include: coct
 historical_changes: []


### PR DESCRIPTION
Hey @beyarkay, there are some new tweet(s) from cape town:

- [1654829406433542144](https://twitter.com/CityofCT/status/1654829406433542144) on Sat, 05 May 2023 at 12:44:10

<table>
<thead>
<td>Tweet text
<td>Parsed YAML

<tr>
<td>

([tweet link](https://twitter.com/CityofCT/status/1654829406433542144))

Load-shedding update 6 May

Eskom Stage 5 active. 

City customers 
6 May
Stage 4: until 16:00
Stage 5: 16:00 - 05:00

7 May 
Stage 5: 05:00 - 05:00

8 May
Stage 4: 05:00 - 16:00
Stage 3: 16:00 - 20:00
Stage 5: 20:00 - 05:00

Updates to follow. Subject to rapid change. 

#CTInfo https://t.co/1AxiOgWU5n

<td>

```yaml
- stage: 5
  start: '2023-05-06T16:00:00'
  finsh: '2023-05-07T05:00:00'
  source: https://twitter.com/CityofCT/status/1654829406433542144
  include: coct
- stage: 5
  start: '2023-05-07T05:00:00'
  finsh: '2023-05-08T05:00:00'
  source: https://twitter.com/CityofCT/status/1654829406433542144
  include: coct
- stage: 4
  start: '2023-05-08T05:00:00'
  finsh: '2023-05-08T16:00:00'
  source: https://twitter.com/CityofCT/status/1654829406433542144
  include: coct
- stage: 3
  start: '2023-05-08T16:00:00'
  finsh: '2023-05-08T20:00:00'
  source: https://twitter.com/CityofCT/status/1654829406433542144
  include: coct
- stage: 5
  start: '2023-05-08T20:00:00'
  finsh: '2023-05-09T05:00:00'
  source: https://twitter.com/CityofCT/status/1654829406433542144
  include: coct

```


</table>
