### PR TITLE
CPT twitter loadshedding update

### DIFF
--- a/manually_specified.yaml
+++ b/manually_specified.yaml
@@ -22,35 +22,24 @@ changes:
   finsh: 2023-05-14T00:00:00
   source: https://twitter.com/Eskom_SA/status/1655187364543643650
   exclude: coct
-
-- stage: 4
-  start: 2023-05-06T13:00:00
-  finsh: 2023-05-06T16:00:00
-  source: https://twitter.com/CityofCT/status/1654829406433542144
+- stage: 6
+  start: '2023-05-07T16:00:00'
+  finsh: '2023-05-08T05:00:00'
+  source: https://twitter.com/CityofCT/status/1655203659179851776
   include: coct
 - stage: 5
-  start: 2023-05-06T16:00:00
-  finsh: 2023-05-07T05:00:00
-  source: https://twitter.com/CityofCT/status/1654829406433542144
-  include: coct
-- stage: 5
-  start: 2023-05-07T05:00:00
-  finsh: 2023-05-08T05:00:00
-  source: https://twitter.com/CityofCT/status/1654829406433542144
+  start: '2023-05-08T05:00:00'
+  finsh: '2023-05-08T16:00:00'
+  source: https://twitter.com/CityofCT/status/1655203659179851776
   include: coct
 - stage: 4
-  start: 2023-05-08T05:00:00
-  finsh: 2023-05-08T16:00:00
-  source: https://twitter.com/CityofCT/status/1654829406433542144
+  start: '2023-05-08T16:00:00'
+  finsh: '2023-05-08T20:00:00'
+  source: https://twitter.com/CityofCT/status/1655203659179851776
   include: coct
-- stage: 3
-  start: 2023-05-08T16:00:00
-  finsh: 2023-05-08T20:00:00
-  source: https://twitter.com/CityofCT/status/1654829406433542144
-  include: coct
-- stage: 5
-  start: 2023-05-08T20:00:00
-  finsh: 2023-05-09T05:00:00
-  source: https://twitter.com/CityofCT/status/1654829406433542144
+- stage: 6
+  start: '2023-05-08T20:00:00'
+  finsh: '2023-05-09T05:00:00'
+  source: https://twitter.com/CityofCT/status/1655203659179851776
   include: coct
 historical_changes: []

--- a/manually_specified.yaml
+++ b/manually_specified.yaml
@@ -22,6 +22,11 @@ changes:
   finsh: 2023-05-14T00:00:00
   source: https://twitter.com/Eskom_SA/status/1655187364543643650
   exclude: coct
+- stage: 5
+  start: '2023-05-07T15:00:00'
+  finsh: '2023-05-07T16:00:00'
+  source: https://twitter.com/CityofCT/status/1655203659179851776
+  include: coct
 - stage: 6
   start: '2023-05-07T16:00:00'
   finsh: '2023-05-08T05:00:00'


### PR DESCRIPTION
Hey @beyarkay, there are some new tweet(s) from cape town:

- [1655203659179851776](https://twitter.com/CityofCT/status/1655203659179851776) on Sun, 05 May 2023 at 13:31:19

<table>
<thead>
<td>Tweet text
<td>Parsed YAML

<tr>
<td>

([tweet link](https://twitter.com/CityofCT/status/1655203659179851776))

Load-shedding update 7 May 

Eskom Stage 6. 

City customers 
7 May 
Stage 5: until 16:00
Stage 6: 16:00 - 05:00 

8 May
Stage 5: 05:00 - 16:00
Stage 4: 16:00 - 20:00
Stage 6: 20:00 - 05:00 

Updates to follow. Subject to rapid change by Eskom.

#CTInfo https://t.co/eupiFkEGSp

<td>

```yaml
- stage: 6
  start: '2023-05-07T16:00:00'
  finsh: '2023-05-08T05:00:00'
  source: https://twitter.com/CityofCT/status/1655203659179851776
  include: coct
- stage: 5
  start: '2023-05-08T05:00:00'
  finsh: '2023-05-08T16:00:00'
  source: https://twitter.com/CityofCT/status/1655203659179851776
  include: coct
- stage: 4
  start: '2023-05-08T16:00:00'
  finsh: '2023-05-08T20:00:00'
  source: https://twitter.com/CityofCT/status/1655203659179851776
  include: coct
- stage: 6
  start: '2023-05-08T20:00:00'
  finsh: '2023-05-09T05:00:00'
  source: https://twitter.com/CityofCT/status/1655203659179851776
  include: coct

```


</table>
