### PR TITLE
CPT twitter loadshedding update

### DIFF
--- a/manually_specified.yaml
+++ b/manually_specified.yaml
@@ -12,39 +12,29 @@
 # See the README.md for more details
 ---
 changes:
-- stage: 5
-  start: 2023-05-06T13:00:00
-  finsh: 2023-05-07T16:00:00
-  source: https://twitter.com/Eskom_SA/status/1654814465508925442
-  exclude: coct
 - stage: 6
   start: 2023-05-07T16:00:00
   finsh: 2023-05-14T00:00:00
   source: https://twitter.com/Eskom_SA/status/1655187364543643650
   exclude: coct
-- stage: 5
-  start: '2023-05-07T15:00:00'
-  finsh: '2023-05-07T16:00:00'
-  source: https://twitter.com/CityofCT/status/1655203659179851776
-  include: coct
 - stage: 6
   start: '2023-05-07T16:00:00'
   finsh: '2023-05-08T05:00:00'
-  source: https://twitter.com/CityofCT/status/1655203659179851776
+  source: https://twitter.com/CityofCT/status/1655584141704921089
   include: coct
 - stage: 5
   start: '2023-05-08T05:00:00'
   finsh: '2023-05-08T16:00:00'
-  source: https://twitter.com/CityofCT/status/1655203659179851776
+  source: https://twitter.com/CityofCT/status/1655584141704921089
   include: coct
 - stage: 4
   start: '2023-05-08T16:00:00'
   finsh: '2023-05-08T20:00:00'
-  source: https://twitter.com/CityofCT/status/1655203659179851776
+  source: https://twitter.com/CityofCT/status/1655584141704921089
   include: coct
 - stage: 6
   start: '2023-05-08T20:00:00'
   finsh: '2023-05-09T05:00:00'
-  source: https://twitter.com/CityofCT/status/1655203659179851776
+  source: https://twitter.com/CityofCT/status/1655584141704921089
   include: coct
 historical_changes: []


### PR DESCRIPTION
Hey @beyarkay, there are some new tweet(s) from cape town:

- [1655584141704921089](https://twitter.com/CityofCT/status/1655584141704921089) on Mon, 05 May 2023 at 14:43:13

<table>
<thead>
<td>Tweet text
<td>Parsed YAML

<tr>
<td>

([tweet link](https://twitter.com/CityofCT/status/1655584141704921089))

Load-shedding update 7 May

Eskom Stage 6.

City customers
7 May
Stage 5: until 16:00
Stage 6: 16:00 - 05:00

8 May
Stage 5: 05:00 - 16:00
Stage 4: 16:00 - 20:00
Stage 6: 20:00 - 05:00

Updates to follow. Subject to rapid change by Eskom. https://t.co/8BOzUKDrar

<td>

```yaml
- stage: 6
  start: '2023-05-07T16:00:00'
  finsh: '2023-05-08T05:00:00'
  source: https://twitter.com/CityofCT/status/1655584141704921089
  include: coct
- stage: 5
  start: '2023-05-08T05:00:00'
  finsh: '2023-05-08T16:00:00'
  source: https://twitter.com/CityofCT/status/1655584141704921089
  include: coct
- stage: 4
  start: '2023-05-08T16:00:00'
  finsh: '2023-05-08T20:00:00'
  source: https://twitter.com/CityofCT/status/1655584141704921089
  include: coct
- stage: 6
  start: '2023-05-08T20:00:00'
  finsh: '2023-05-09T05:00:00'
  source: https://twitter.com/CityofCT/status/1655584141704921089
  include: coct

```


</table>
