### PR TITLE
CPT twitter loadshedding update

### DIFF
--- a/manually_specified.yaml
+++ b/manually_specified.yaml
@@ -13,16 +13,6 @@
 ---
 changes:
 - stage: 4
-  start: 2023-05-15T05:00:00
-  finsh: 2023-05-15T15:00:00
-  source: https://twitter.com/Eskom_SA/status/1658086187477659649
-  exclude: coct
-- stage: 6
-  start: 2023-05-15T16:00:00
-  finsh: 2023-05-16T05:00:00
-  source: https://twitter.com/Eskom_SA/status/1657681204747857921
-  exclude: coct
-- stage: 4
   start: 2023-05-16T05:00:00
   finsh: 2023-05-16T16:00:00
   source: https://twitter.com/Eskom_SA/status/1657681204747857921
@@ -57,34 +47,29 @@ changes:
   finsh: 2023-05-19T16:00:00
   source: https://twitter.com/Eskom_SA/status/1657681204747857921
   exclude: coct
-- stage: 3
-  start: '2023-05-15T05:00:00'
-  finsh: '2023-05-15T15:00:00'
-  source: https://twitter.com/CityofCT/status/1658089742397853696
-  include: coct
-- stage: 4
-  start: '2023-05-15T15:00:00'
-  finsh: '2023-05-15T20:00:00'
-  source: https://twitter.com/CityofCT/status/1658089742397853696
-  include: coct
-- stage: 6
-  start: '2023-05-15T20:00:00'
-  finsh: '2023-05-16T05:00:00'
-  source: https://twitter.com/CityofCT/status/1658089742397853696
-  include: coct
-- stage: 3
-  start: '2023-05-16T05:00:00'
-  finsh: '2023-05-16T16:00:00'
-  source: https://twitter.com/CityofCT/status/1658089742397853696
-  include: coct
 - stage: 4
   start: '2023-05-16T16:00:00'
   finsh: '2023-05-16T20:00:00'
-  source: https://twitter.com/CityofCT/status/1658089742397853696
+  source: https://twitter.com/CityofCT/status/1658487390581964800
   include: coct
 - stage: 6
   start: '2023-05-16T20:00:00'
   finsh: '2023-05-17T05:00:00'
-  source: https://twitter.com/CityofCT/status/1658089742397853696
+  source: https://twitter.com/CityofCT/status/1658487390581964800
+  include: coct
+- stage: 3
+  start: '2023-05-17T05:00:00'
+  finsh: '2023-05-17T16:00:00'
+  source: https://twitter.com/CityofCT/status/1658487390581964800
+  include: coct
+- stage: 4
+  start: '2023-05-17T16:00:00'
+  finsh: '2023-05-17T20:00:00'
+  source: https://twitter.com/CityofCT/status/1658487390581964800
+  include: coct
+- stage: 6
+  start: '2023-05-17T20:00:00'
+  finsh: '2023-05-18T05:00:00'
+  source: https://twitter.com/CityofCT/status/1658487390581964800
   include: coct
 historical_changes: []


### PR DESCRIPTION
Hey @beyarkay, there are some new tweet(s) from cape town:

- [1658487390581964800](https://twitter.com/CityofCT/status/1658487390581964800) on Tue, 05 May 2023 at 14:59:41

<table>
<thead>
<td>Tweet text
<td>Parsed YAML

<tr>
<td>

([tweet link](https://twitter.com/CityofCT/status/1658487390581964800))

Load-shedding update 16 May

City customers
16 May
Stage 4: 16:00 - 20:00
Stage 6: 20:00 - 05:00

17 May
Stage 3: 05:00 - 16:00
Stage 4: 16:00 - 20:00
Stage 6: 20:00 - 05:00

*Updates likely.
*Subject to rapid change by Eskom. https://t.co/NSsxwyxd8B

<td>

```yaml
- stage: 4
  start: '2023-05-16T16:00:00'
  finsh: '2023-05-16T20:00:00'
  source: https://twitter.com/CityofCT/status/1658487390581964800
  include: coct
- stage: 6
  start: '2023-05-16T20:00:00'
  finsh: '2023-05-17T05:00:00'
  source: https://twitter.com/CityofCT/status/1658487390581964800
  include: coct
- stage: 3
  start: '2023-05-17T05:00:00'
  finsh: '2023-05-17T16:00:00'
  source: https://twitter.com/CityofCT/status/1658487390581964800
  include: coct
- stage: 4
  start: '2023-05-17T16:00:00'
  finsh: '2023-05-17T20:00:00'
  source: https://twitter.com/CityofCT/status/1658487390581964800
  include: coct
- stage: 6
  start: '2023-05-17T20:00:00'
  finsh: '2023-05-18T05:00:00'
  source: https://twitter.com/CityofCT/status/1658487390581964800
  include: coct

```


</table>
