### PR TITLE
CPT twitter loadshedding update

### DIFF
--- a/manually_specified.yaml
+++ b/manually_specified.yaml
@@ -13,16 +13,6 @@
 ---
 changes:
 - stage: 4
-  start: 2023-05-30T05:00:00
-  finsh: 2023-05-30T16:00:00
-  source: https://twitter.com/Eskom_SA/status/1663156249087574017
-  exclude: coct
-- stage: 6
-  start: 2023-05-30T16:00:00
-  finsh: 2023-05-31T05:00:00
-  source: https://twitter.com/Eskom_SA/status/1663156249087574017
-  exclude: coct
-- stage: 4
   start: 2023-05-31T05:00:00
   finsh: 2023-05-31T16:00:00
   source: https://twitter.com/Eskom_SA/status/1663156249087574017
@@ -72,34 +62,14 @@ changes:
   finsh: 2023-06-05T00:00:00
   source: https://twitter.com/Eskom_SA/status/1663156249087574017
   exclude: coct
-- stage: 3
-  start: '2023-05-30T05:00:00'
-  finsh: '2023-05-30T16:00:00'
-  source: https://twitter.com/CityofCT/status/1663452536026861568
-  include: coct
-- stage: 4
-  start: '2023-05-30T16:00:00'
-  finsh: '2023-05-30T20:00:00'
-  source: https://twitter.com/CityofCT/status/1663452536026861568
-  include: coct
-- stage: 6
-  start: '2023-05-30T20:00:00'
-  finsh: '2023-05-31T05:00:00'
-  source: https://twitter.com/CityofCT/status/1663452536026861568
-  include: coct
-- stage: 3
-  start: '2023-05-31T05:00:00'
-  finsh: '2023-05-31T16:00:00'
-  source: https://twitter.com/CityofCT/status/1663452536026861568
-  include: coct
 - stage: 4
   start: '2023-05-31T16:00:00'
   finsh: '2023-05-31T20:00:00'
-  source: https://twitter.com/CityofCT/status/1663452536026861568
+  source: https://twitter.com/CityofCT/status/1663929404882296835
   include: coct
 - stage: 6
   start: '2023-05-31T20:00:00'
   finsh: '2023-06-01T05:00:00'
-  source: https://twitter.com/CityofCT/status/1663452536026861568
+  source: https://twitter.com/CityofCT/status/1663929404882296835
   include: coct
 historical_changes: []

--- a/manually_specified.yaml
+++ b/manually_specified.yaml
@@ -72,4 +72,37 @@ changes:
   finsh: '2023-06-01T05:00:00'
   source: https://twitter.com/CityofCT/status/1663929404882296835
   include: coct
+
+- stage: 3
+  start: '2023-06-01T05:00:00'
+  finsh: '2023-06-01T16:00:00'
+  source: https://twitter.com/CityofCT/status/1663929404882296835
+  include: coct
+- stage: 5
+  start: '2023-06-01T16:00:00'
+  finsh: '2023-06-01T22:00:00'
+  source: https://twitter.com/CityofCT/status/1663929404882296835
+  include: coct
+- stage: 6
+  start: '2023-06-01T22:00:00'
+  finsh: '2023-06-02T05:00:00'
+  source: https://twitter.com/CityofCT/status/1663929404882296835
+  include: coct
+
+- stage: 3
+  start: '2023-06-02T05:00:00'
+  finsh: '2023-06-02T16:00:00'
+  source: https://twitter.com/CityofCT/status/1663929404882296835
+  include: coct
+- stage: 5
+  start: '2023-06-02T16:00:00'
+  finsh: '2023-06-02T22:00:00'
+  source: https://twitter.com/CityofCT/status/1663929404882296835
+  include: coct
+- stage: 6
+  start: '2023-06-02T22:00:00'
+  finsh: '2023-06-03T05:00:00'
+  source: https://twitter.com/CityofCT/status/1663929404882296835
+  include: coct
+
 historical_changes: []


### PR DESCRIPTION
Hey @beyarkay, there are some new tweet(s) from cape town:

- [1663929404882296835](https://twitter.com/CityofCT/status/1663929404882296835) on Wed, 05 May 2023 at 15:24:19

<table>
<thead>
<td>Tweet text
<td>Parsed YAML

<tr>
<td>

([tweet link](https://twitter.com/CityofCT/status/1663929404882296835))

Load-shedding update 31 May

City customers
31 May
Stage 4: 16:00 - 20:00
Stage 6: 20:00 - 05:00

1 June
Stage 3: 05:00 - 16:00
Stage 5: 16:00 - 22:00
Stage 6: 22:00 - 05:00

2 June
Stage 3: 05:00 - 16:00
Stage 5: 16:00 - 22:00
Stage 6: 22:00 - 05:00

*Updates likely. https://t.co/4PZ2A34IXC

<td>

```yaml
- stage: 4
  start: '2023-05-31T16:00:00'
  finsh: '2023-05-31T20:00:00'
  source: https://twitter.com/CityofCT/status/1663929404882296835
  include: coct
- stage: 6
  start: '2023-05-31T20:00:00'
  finsh: '2023-06-01T05:00:00'
  source: https://twitter.com/CityofCT/status/1663929404882296835
  include: coct

```


</table>
